### PR TITLE
add multiple entrypoint support - fixes #63

### DIFF
--- a/minidlna/README.md
+++ b/minidlna/README.md
@@ -21,4 +21,19 @@ docker run -d --net=host \
   vladgh/minidlna
 ```
 
+### Multiple Media dirs
+
+Any environment variable starting MEDIA_DIR will be treated as an additional media_dir directive.
+
+```
+docker run -d --net=host \
+  -p 8200:8200 \
+  -v <media dir on host>:/media/audio \
+  -v <media dir on host>:/media/video \
+  -e MEDIADIR_1=A:/media/audio \
+  -e MEDIADIR_1=V:/media/video \
+  -e MINIDLNA_FRIENDLY_NAME=MyMini \
+  vladgh/minidlna
+```
+
 See: http://manpages.ubuntu.com/manpages/raring/man5/minidlna.conf.5.html

--- a/minidlna/README.md
+++ b/minidlna/README.md
@@ -23,15 +23,18 @@ docker run -d --net=host \
 
 ### Multiple Media dirs
 
-Any environment variable starting MEDIA_DIR will be treated as an additional media_dir directive.
+Any environment variable starting with `MINIDLNA_MEDIA_DIR` will be treated as
+an additional `media_dir` directive and any suffix in the variable name will
+be trimmed (ex: `MINIDLNA_MEDIA_DIR_1`). This way you can eclare multiple
+`media_dir` directives
 
 ```
 docker run -d --net=host \
   -p 8200:8200 \
   -v <media dir on host>:/media/audio \
   -v <media dir on host>:/media/video \
-  -e MEDIADIR_1=A:/media/audio \
-  -e MEDIADIR_1=V:/media/video \
+  -e MINIDLNA_MEDIA_DIR_1=A:/media/audio \
+  -e MINIDLNA_MEDIA_DIR_2=V:/media/video \
   -e MINIDLNA_FRIENDLY_NAME=MyMini \
   vladgh/minidlna
 ```

--- a/minidlna/entrypoint.sh
+++ b/minidlna/entrypoint.sh
@@ -15,6 +15,11 @@ for VAR in $(env); do
     minidlna_value=$(echo "$VAR" | sed -r "s/.*=(.*)/\1/g")
     echo "${minidlna_name}=${minidlna_value}" >> /etc/minidlna.conf
   fi
+  if [[ "$VAR" =~ ^MEDIA_DIR ]]; then
+    minidlna_name=media_dir
+    minidlna_value=$(echo "$VAR" | sed -r "s/.*=(.*)/\1/g")
+    echo "${minidlna_name}=${minidlna_value}" >> /etc/minidlna.conf
+  fi
 done
 
 # Start daemon

--- a/minidlna/entrypoint.sh
+++ b/minidlna/entrypoint.sh
@@ -11,13 +11,12 @@ IFS=$'\n\t'
 > /etc/minidlna.conf
 for VAR in $(env); do
   if [[ "$VAR" =~ ^MINIDLNA_ ]]; then
-    minidlna_name=$(echo "$VAR" | sed -r "s/MINIDLNA_(.*)=.*/\1/g" | tr '[:upper:]' '[:lower:]')
-    minidlna_value=$(echo "$VAR" | sed -r "s/.*=(.*)/\1/g")
-    echo "${minidlna_name}=${minidlna_value}" >> /etc/minidlna.conf
-  fi
-  if [[ "$VAR" =~ ^MEDIA_DIR ]]; then
-    minidlna_name=media_dir
-    minidlna_value=$(echo "$VAR" | sed -r "s/.*=(.*)/\1/g")
+    if [[ "$VAR" =~ ^MINIDLNA_MEDIA_DIR ]]; then
+      minidlna_name='media_dir'
+    else
+      minidlna_name=$(echo "$VAR" | sed -r "s/MINIDLNA_(.*)=.*/\\1/g" | tr '[:upper:]' '[:lower:]')
+    fi
+    minidlna_value=$(echo "$VAR" | sed -r "s/.*=(.*)/\\1/g")
     echo "${minidlna_name}=${minidlna_value}" >> /etc/minidlna.conf
   fi
 done


### PR DESCRIPTION
Since you cannot specify the same environment variable multiple times, and minidnla requires each media directory to be passed as a separate parameter, I added another check for any environment variable starting with `MEDIA_DIR`. This would resolve #63. Existing configs using `MINIDNLA_MEDIA_DIR=` will still work as well.