### PR TITLE
Support running MiniDLNA as non-root

### DIFF
--- a/minidlna/Dockerfile
+++ b/minidlna/Dockerfile
@@ -4,6 +4,13 @@ LABEL maintainer "Vlad Ghinea vlad@ghn.me"
 # Install packages
 RUN apk --no-cache add bash minidlna tini
 
+#Set User to MiniDLNA, to prevent it from running as root user
+#We set the read/write permissions to everyone to give the user the possibility to run the container as any desired user 
+RUN chown minidlna:minidlna /etc/minidlna.conf && chmod ugo+w /etc/minidlna.conf
+RUN mkdir /minidlna && chown minidlna:minidlna /minidlna && chmod 777 /minidlna
+USER minidlna
+RUN mkdir /minidlna/cache && chmod 777 /minidlna/cache
+
 # Entrypoint
 COPY entrypoint.sh /
 ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh"]

--- a/minidlna/entrypoint.sh
+++ b/minidlna/entrypoint.sh
@@ -3,9 +3,10 @@
 # Bash strict mode
 set -euo pipefail
 IFS=$'\n\t'
+pidfile="/minidlna/minidlna.pid"
 
 # Remove old pid if it exists
-[ -f /var/run/minidlna/minidlna.pid ] && rm -f /var/run/minidlna/minidlna.pid
+[ -f $pidfile ] && rm -f $pidfile
 
 # Change configuration
 : > /etc/minidlna.conf
@@ -20,6 +21,9 @@ for VAR in $(env); do
     echo "${minidlna_name}=${minidlna_value}" >> /etc/minidlna.conf
   fi
 done
+# Directories have to be in a writeable place
+echo "db_dir=/minidlna/cache" >> /etc/minidlna.conf
+echo "log_dir=/minidlna/" >>/etc/minidlna.conf
 
 # Start daemon
-exec /usr/sbin/minidlnad -S "$@"
+exec /usr/sbin/minidlnad -P $pidfile -S "$@"


### PR DESCRIPTION
I changed the files in a way thath MiniDLNA is now running a non-root user
(according to https://help.ubuntu.com/community/MiniDLNA). The aim: improving security and following best practices (https://docs.docker.com/develop/develop-images/dockerfile_best-practices/).

It also enables the user to run the container as an arbitrary user. This was not possible till now due to missing read/write permissions in the container. 

Side-effects:
When mounting a volume as a media folder, this folder needs the right permissions for MiniDLNA to be able to access it. This was the same before, but as MiniDLNA now runs as non-root has less access permissions on the host system.

