### PR TITLE
Trigger build when publishing a release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
     branches:
       - '*'
+  release:
+    types:
+      - published
 
 jobs:
   build:


### PR DESCRIPTION
Apparently switching from a draft release to a published released doesn't trigger a tag push event. 