### PR TITLE
feat(minidlna): Add notify interval configuration

### DIFF
--- a/minidlna/README.md
+++ b/minidlna/README.md
@@ -63,3 +63,19 @@ docker run -d \
 ```
 
 See: <http://manpages.ubuntu.com/manpages/raring/man5/minidlna.conf.5.html>
+
+### Notify interval
+
+By default, `minidlna` will announce itself to the network every 895 seconds (roughly 15 minutes).
+For some scenarios, like using a smart TV that only gets switched on on when you want to watch something, you might need to wait up to that amount of time for the service to show up.
+You can use the `MINIDLNA_NOTIFY_INTERVAL` environment variable to change the notify interval to the desired number of seconds like so:
+
+```sh
+docker run -d \
+  --net=host \
+  -v <media dir on host>:/media \
+  -e MINIDLNA_MEDIA_DIR=/media \
+  -e MINIDLNA_FRIENDLY_NAME=MyMini \
+  -e MINIDLNA_NOTIFY_INTERVAL=30 \
+  vladgh/minidlna
+```

--- a/minidlna/entrypoint.sh
+++ b/minidlna/entrypoint.sh
@@ -31,6 +31,7 @@ echo '=== Set standard configuration'
 export MINIDLNA_DB_DIR="${MINIDLNA_DB_DIR:-/minidlna/cache}"
 export MINIDLNA_LOG_DIR="${MINIDLNA_LOG_DIR:-/minidlna}"
 export MINIDLNA_INOTIFY="${MINIDLNA_INOTIFY:-yes}"
+export MINIDLNA_NOTIFY_INTERVAL="${MINIDLNA_NOTIFY_INTERVAL:-895}"
 
 echo '=== Set configuration from environment variables'
 : > /etc/minidlna.conf


### PR DESCRIPTION
This adds the `MINIDLNA_NOTIFY_INTERVAL` configuration variable, which can be useful for situations where the device you need DLNA advertised to is not constantly running, and would otherwise need to wait up to full 15 minutes for the service advertisement after boot.