### PR TITLE
Fix s3 sync error

### DIFF
--- a/s3sync/entrypoint.sh
+++ b/s3sync/entrypoint.sh
@@ -49,6 +49,7 @@ sync_files(){
   fi
 
   log "Sync '${src}' to '${dst}'"
+  log "aws s3 sync \"$src\" \"$dst\" $sync_cmd"
   if ! eval aws s3 sync "$src" "$dst" $sync_cmd; then
     log "Could not sync '${src}' to '${dst}'" >&2; exit 1
   fi

--- a/s3sync/entrypoint.sh
+++ b/s3sync/entrypoint.sh
@@ -49,7 +49,7 @@ sync_files(){
   fi
 
   log "Sync '${src}' to '${dst}'"
-  if ! eval aws s3 sync "$sync_cmd" "$src" "$dst"; then
+  if ! eval aws s3 sync "$src" "$dst" $sync_cmd; then
     log "Could not sync '${src}' to '${dst}'" >&2; exit 1
   fi
 }


### PR DESCRIPTION
The s3 sync parameter, `"$sync_cmd"` should be at the end
I also added log of the command executed.

Reference: https://docs.aws.amazon.com/cli/latest/reference/s3/sync.html#examples

```
aws s3 sync s3://my-us-west-2-bucket s3://my-us-east-1-bucket \
    --source-region us-west-2 \
    --region us-east-1
```

---
Sidenote: I've pull this repo because I use this image for my raspberry pi 4, but it doesn't have compatible image for arm64. 
Then I built it from my raspberry pi 4, try to config it again, but it always have error because the destination parameter on the wrong place