### PR TITLE
Set workdir

### DIFF
--- a/gpg/Dockerfile
+++ b/gpg/Dockerfile
@@ -5,5 +5,6 @@ LABEL maintainer "Vlad Ghinea vlad@ghn.me"
 RUN apk --no-cache add gnupg haveged tini
 
 # Entrypoint
+WORKDIR /gpg
 ENTRYPOINT ["/sbin/tini", "--", "gpg"]
 CMD ["--version"]

--- a/gpg/README.md
+++ b/gpg/README.md
@@ -17,7 +17,7 @@ docker run -it -v /path/to/keys/store:/root/.gnupg -e GPG_TTY=/dev/console vladg
 - Encrypt with symmetric cipher only. This command asks for a passphrase.
 
 ```SH
-docker run -it -v $(pwd):/gpg -e GPG_TTY=/dev/console vladgh/gpg --symmetric /gpg/my_file
+docker run -it -v $(pwd):/gpg -e GPG_TTY=/dev/console vladgh/gpg --symmetric my_file
 ```
 
 - Generate GPG key


### PR DESCRIPTION
Hey, if we change the workdir to the directory we are mounting then we don't need to specify the path in the command part. so we can just cal `.. vladgh/gpg -ca file` instead of `.. vladgh/gpg -ca /gpg/file`.