### PR TITLE
Add support for MINIDLNA_ROOT_CONTAINER

### DIFF
--- a/minidlna/README.md
+++ b/minidlna/README.md
@@ -62,6 +62,29 @@ docker run -d \
   vladgh/minidlna
 ```
 
+### Root Container
+
+By default, MiniDLNA uses the standard container as the root of the tree exposed to clients.
+You can use the `MINIDLNA_ROOT_CONTAINER` environment variable to specify a different container as the root:
+
+- `.` to use the standard container (this is the default)
+- `B` to use the "Browse Directory" container
+- `M` to use the "Music" container
+- `V` to use the "Video" container
+- `P` to use the "Pictures" container
+
+If you specify `B` and the client device is audio only, then "Music/Folders" will be used as root container and you won't see Videos.
+
+```sh
+docker run -d \
+  --net=host \
+  -v <media dir on host>:/media \
+  -e MINIDLNA_MEDIA_DIR=/media \
+  -e MINIDLNA_FRIENDLY_NAME=MyMini \
+  -e MINIDLNA_ROOT_CONTAINER=M \
+  vladgh/minidlna
+```
+
 See: <http://manpages.ubuntu.com/manpages/raring/man5/minidlna.conf.5.html>
 
 ### Notify interval

--- a/minidlna/entrypoint.sh
+++ b/minidlna/entrypoint.sh
@@ -36,8 +36,8 @@ export MINIDLNA_ROOT_CONTAINER="${MINIDLNA_ROOT_CONTAINER:-.}"
 
 # Validate MINIDLNA_ROOT_CONTAINER
 if [[ ! "$MINIDLNA_ROOT_CONTAINER" =~ ^(\.|B|M|V|P)$ ]]; then
-  echo "Invalid MINIDLNA_ROOT_CONTAINER value: $MINIDLNA_ROOT_CONTAINER. Must be one of: ., B, M, V, P" >&2
-  exit 1
+  echo "Invalid MINIDLNA_ROOT_CONTAINER value: $MINIDLNA_ROOT_CONTAINER. Must be one of: ., B, M, V, P. Falling back to default '.'" >&2
+  export MINIDLNA_ROOT_CONTAINER="."
 fi
 
 echo '=== Set configuration from environment variables'

--- a/minidlna/entrypoint.sh
+++ b/minidlna/entrypoint.sh
@@ -32,6 +32,13 @@ export MINIDLNA_DB_DIR="${MINIDLNA_DB_DIR:-/minidlna/cache}"
 export MINIDLNA_LOG_DIR="${MINIDLNA_LOG_DIR:-/minidlna}"
 export MINIDLNA_INOTIFY="${MINIDLNA_INOTIFY:-yes}"
 export MINIDLNA_NOTIFY_INTERVAL="${MINIDLNA_NOTIFY_INTERVAL:-895}"
+export MINIDLNA_ROOT_CONTAINER="${MINIDLNA_ROOT_CONTAINER:-.}"
+
+# Validate MINIDLNA_ROOT_CONTAINER
+if [[ ! "$MINIDLNA_ROOT_CONTAINER" =~ ^(\.|B|M|V|P)$ ]]; then
+  echo "Invalid MINIDLNA_ROOT_CONTAINER value: $MINIDLNA_ROOT_CONTAINER. Must be one of: ., B, M, V, P" >&2
+  exit 1
+fi
 
 echo '=== Set configuration from environment variables'
 : > /etc/minidlna.conf


### PR DESCRIPTION
The proposed change is exposing the minidlna's _root_container_ option in order to be able to change the tree exposed to clients. 
This PR resolves issue #422 
